### PR TITLE
Adding AWS Instance Reports

### DIFF
--- a/get_all_inst.py
+++ b/get_all_inst.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+
+# Script to look at all running AWS instances and show a comparison between active & reserved instance types.
+
+from datetime import date, timedelta
+import os
+from os.path import expanduser
+import tabulate
+
+
+home_dir = expanduser("~")
+report_delete_date = date.today() - timedelta(days=7)
+report_home = home_dir + '/reports/instances'
+
+def get_all_instances():
+
+
+    from boto.ec2 import connect_to_region
+    import time
+    # Setting global variables
+    envn = 'RIComparisonServiceAccount'  # this is used to call the proper .aws profile for credentials
+    region = 'us-east-1'
+    ec2conn = connect_to_region(region, profile_name=envn)
+    instance_count = 0
+    instance_report = open(report_home + '/all_instances_' + time.strftime("%Y%m%d" + ".txt"),'w')
+
+    try:
+        reservations = ec2conn.get_all_instances()  # return all AWS instances
+        mydict = {}
+        for res in reservations:
+            for inst in res.instances:
+                instance_count += 1
+                if 'Name' in inst.tags:
+                    mydict[inst.tags['Name']] = { 'id': inst.id, 'state': inst.state, 'type': inst.instance_type, 'name': inst.tags['Name'] }
+                    ordered_dict = sorted(mydict.itervalues(), key=lambda x: x['type'])
+
+        instance_report.write(tabulate.tabulate(ordered_dict, headers="keys"))
+        instance_report.write("\n\nInstance Count: " + str(instance_count) + "\n")
+
+    except Exception, e:
+        print e
+
+get_all_instances()
+
+try:
+    os.remove(report_home + '/all_instances_' + str(report_delete_date.strftime("%Y%m%d")) + ".txt")
+except OSError:
+    pass

--- a/get_all_ri.py
+++ b/get_all_ri.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python
+# Script to look at all running AWS Reserved Instances and show type + count.
+from datetime import date, timedelta
+import os
+from os.path import expanduser
+import tabulate
+
+home_dir = expanduser("~")
+report_delete_date = date.today() - timedelta(days=7)
+report_home = home_dir + '/reports/instances'
+
+
+def get_all_reserved_instances():
+    from boto.ec2 import connect_to_region
+    import time
+    # Setting global variables
+    envn = 'RIComparisonServiceAccount'  # this is used to call the proper .aws profile for credentials
+    region = 'us-east-1'
+    ec2conn = connect_to_region(region, profile_name=envn)
+    ri_report = open(report_home + '/all_reserved_instances_' + time.strftime("%Y%m%d" + ".txt"), 'w')
+    total_instance_types = 0
+    total_reserved_instances = 0
+
+    try:
+        reservations = ec2conn.get_all_reserved_instances()  # return all AWS instances
+        mydict = {}
+        for res in reservations:
+            if res.state == "active":
+                mydict[res.id] = {'type': res.instance_type, 'count': res.instance_count,
+                                  'offer': res.offering_type, 'platform': res.description}
+
+            total_reserved_instances += 1
+            if res.state == "active":
+                total_instance_types += res.instance_count
+
+        ordered_dict = sorted(mydict.itervalues(), key=lambda x: x['type'])
+        ri_report.write(tabulate.tabulate(ordered_dict, headers="keys"))
+        ri_report.write("\n\n" + "Total Reserved Instance Types: " + str(total_reserved_instances) + "\n")
+        ri_report.write("Total Reserved Instances: " + str(total_instance_types) + "\n")
+
+    except Exception, e:
+        print e
+
+
+get_all_reserved_instances()
+
+try:
+    os.remove(report_home + '/instances/all_reserved_instances_' + str(report_delete_date.strftime("%Y%m%d")) + ".txt")
+except OSError:
+    pass


### PR DESCRIPTION
get_all_inst.py - Pull a list of all Instances (status, type, ID, name) and sort them by type.  Include a count of all currently active instances.

get_all_ri.py - Pull a list of all Reserved Instances (instance_count, platform, type, offer) and sort them by type.  Include a count of all currently reserved instances along with a count of instance_types.

You will need to edit the AWS config files to use boto_connect_to_region.
 -- ~/.aws/credentials -- Add access_key_id & secret_access_key of AWS account
 -- ~/.aws/config -- Add account, output, region
